### PR TITLE
Backend implementation for Infix to Postfix conversion

### DIFF
--- a/portfolio/app/routes/__init__.py
+++ b/portfolio/app/routes/__init__.py
@@ -4,3 +4,4 @@ This module is used to import all the routes from the other modules.
 
 from .index import *
 from .linked_list import *
+from .infix_to_postfix import *

--- a/portfolio/app/routes/infix_to_postfix.py
+++ b/portfolio/app/routes/infix_to_postfix.py
@@ -1,0 +1,72 @@
+from app import app
+from flask import render_template, request, redirect, url_for
+from .linked_list import LinkedList
+
+
+# Helper function to determine if a character is an operator
+def is_operator(char):
+    return char in "+-*/^" # Returns True or False
+
+
+# Helper function to define operator precedence
+def precedence(operator):
+    if operator in "+-":
+        return 1
+    if operator in "*/":
+        return 2
+    if operator == "^":
+        return 3
+    return 0
+
+
+# Infix to Postfix conversion
+def infix_to_postfix(expression):
+    operator_stack = LinkedList()  # Stack to hold operators
+    output = LinkedList()  # Linked list (treated as stack) to hold the postfix expression
+    expression = expression.replace(" ", "")  # Removes spaces before transforming to postfix
+    
+    for element in expression:  
+        if element.isalnum():  # Checks if element is an operand
+            output.insert_at_end(element) # Pushed to output stack 
+        elif element == '(':  
+            operator_stack.insert_at_beginning(element) # Pushed to operator stack 
+        elif element == ')':  
+            # If the top of the operator_stack is an openning bracket
+            while operator_stack.head and operator_stack.head.data != '(': 
+                # Pops elemnent from the operator_stack and pushed to the output stack
+                output.insert_at_end(operator_stack.remove_beginning()) 
+            operator_stack.remove_beginning()  # Pops the '(' from the stack
+        elif is_operator(element):  
+            # While an operator at the top of the operators stack has greater/equal precedence than element
+            while (operator_stack.head and precedence(operator_stack.head.data) >= precedence(element)): 
+                # Pop operator from the operator_stack into the output stack 
+                output.insert_at_end(operator_stack.remove_beginning()) 
+            operator_stack.insert_at_beginning(element) # Pushes element in the outputr stack
+
+    # Pop remaining operators from the operator stack to the output stack 
+    while operator_stack.head:
+        output.insert_at_end(operator_stack.remove_beginning())
+    
+    return output.to_list()  # Returns a list for readability
+
+
+
+
+
+@app.route('/infix-to-postfix', methods=['GET', 'POST'])
+def Infix_to_Postfix():
+    output = ""  # Initialize output
+    
+    if request.method == 'POST':
+        # Handle form submission (POST)
+        input_expression = request.form['input']  # Match the form field name
+        output = infix_to_postfix(input_expression)  # Process the input
+        
+        # Redirect to the same page with the output (GET request)
+        return redirect(url_for('Infix_to_Postfix', output=" ".join(output)))
+    
+    # Handle GET request: check for 'output' parameter
+    if 'output' in request.args:    
+        output = request.args['output']
+    
+    return render_template('infix_to_postfix.html', title="Infix To Postfix", output=output)

--- a/portfolio/app/templates/infix_to_postfix.html
+++ b/portfolio/app/templates/infix_to_postfix.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}</title>
+</head>
+<body>
+    <!-- Form for input and output -->
+    <form action="/infix-to-postfix" method="POST">
+        <label for="inputBox">Enter Input:</label>
+        <input type="text" id="inputBox" name="input" required>
+        <br><br>
+    
+        <label for="outputBox">Output:</label>
+        <textarea id="outputBox" name="output" readonly>{{ output }}</textarea>
+        <br><br>
+    
+        <button type="submit">Submit</button>
+    </form>
+</body>
+</html>


### PR DESCRIPTION
This pull request introduces the backend logic for converting infix expressions to postfix notation. It includes:
- A stack-based approach implemented using a custom LinkedList class to handle the conversion.
- Helper functions for checking operator precedence and identifying operators.
- A new /infix-to-postfix route in the Flask application that accepts user input via a form, processes it, and returns the postfix result.
- A corresponding HTML form in the infix_to_postfix.html template to capture input and display the result.