### PR TITLE
Fix infix to postfix conversion to handle multi-digit numbers

### DIFF
--- a/portfolio/app/routes/infix_to_postfix.py
+++ b/portfolio/app/routes/infix_to_postfix.py
@@ -5,7 +5,7 @@ from .linked_list import LinkedList
 
 # Helper function to determine if a character is an operator
 def is_operator(char):
-    return char in "+-*/^" # Returns True or False
+    return char in "+-*/^"  # Returns True or False
 
 
 # Helper function to define operator precedence
@@ -25,32 +25,37 @@ def infix_to_postfix(expression):
     output = LinkedList()  # Linked list (treated as stack) to hold the postfix expression
     expression = expression.replace(" ", "")  # Removes spaces before transforming to postfix
     
-    for element in expression:  
-        if element.isalnum():  # Checks if element is an operand
-            output.insert_at_end(element) # Pushed to output stack 
-        elif element == '(':  
-            operator_stack.insert_at_beginning(element) # Pushed to operator stack 
-        elif element == ')':  
-            # If the top of the operator_stack is an openning bracket
-            while operator_stack.head and operator_stack.head.data != '(': 
-                # Pops elemnent from the operator_stack and pushed to the output stack
-                output.insert_at_end(operator_stack.remove_beginning()) 
-            operator_stack.remove_beginning()  # Pops the '(' from the stack
-        elif is_operator(element):  
+    i = 0
+    while i < len(expression):
+        if expression[i].isdigit():  # Checks if element is a digit
+            num = expression[i]
+            while i + 1 < len(expression) and expression[i + 1].isdigit():
+                i += 1
+                num += expression[i]
+            output.insert_at_end(num)  # Push the full number to the output stack
+        elif expression[i].isalpha():  # Checks if element is an operand
+            output.insert_at_end(expression[i])  # Push to output stack
+        elif expression[i] == '(':
+            operator_stack.insert_at_beginning(expression[i])  # Push to operator stack
+        elif expression[i] == ')':
+            # If the top of the operator_stack is an opening bracket
+            while operator_stack.head and operator_stack.head.data != '(':
+                # Pop element from the operator_stack and push to the output stack
+                output.insert_at_end(operator_stack.remove_beginning())
+            operator_stack.remove_beginning()  # Pop the '(' from the stack
+        elif is_operator(expression[i]):
             # While an operator at the top of the operators stack has greater/equal precedence than element
-            while (operator_stack.head and precedence(operator_stack.head.data) >= precedence(element)): 
-                # Pop operator from the operator_stack into the output stack 
-                output.insert_at_end(operator_stack.remove_beginning()) 
-            operator_stack.insert_at_beginning(element) # Pushes element in the outputr stack
+            while (operator_stack.head and precedence(operator_stack.head.data) >= precedence(expression[i])):
+                # Pop operator from the operator_stack into the output stack
+                output.insert_at_end(operator_stack.remove_beginning())
+            operator_stack.insert_at_beginning(expression[i])  # Push element in the operator stack
+        i += 1
 
-    # Pop remaining operators from the operator stack to the output stack 
+    # Pop remaining operators from the operator stack to the output stack
     while operator_stack.head:
         output.insert_at_end(operator_stack.remove_beginning())
     
     return output.to_list()  # Returns a list for readability
-
-
-
 
 
 @app.route('/infix-to-postfix', methods=['GET', 'POST'])


### PR DESCRIPTION
- Updated the infix_to_postfix function to correctly parse and group multiple-digit numbers.
- Modified the loop to combine consecutive digits into a single number before pushing to the output stack.
- Ensured that the function handles multi-digit numbers by iterating through the digits and combining them.
- This fix allows expressions like 68+911+150 to be correctly converted to postfix notation.