### PR TITLE
implement backend logic for queue and double-ended queue

### DIFF
--- a/portfolio/app/routes/__init__.py
+++ b/portfolio/app/routes/__init__.py
@@ -5,3 +5,4 @@ This module is used to import all the routes from the other modules.
 from .index import *
 from .linked_list import *
 from .infix_to_postfix import *
+from .queue import *

--- a/portfolio/app/routes/linked_list.py
+++ b/portfolio/app/routes/linked_list.py
@@ -104,6 +104,20 @@ class LinkedList:
             result.append(current.data)
             current = current.next
         return result
+    
+    # Converts the linked list to a string (for display purposes)
+    def to_string(self):
+        elements = []
+        current = self.head
+        while current:
+            elements.append(str(current.data))
+            current = current.next
+        return ' -> '.join(elements) if elements else 'Empty'
+    
+    # Empties the list
+    def clear(self):
+        self.head = None
+        self.tail = None
 
 # Create a LinkedList instance
 linkedlist = LinkedList()

--- a/portfolio/app/routes/queue.py
+++ b/portfolio/app/routes/queue.py
@@ -1,0 +1,110 @@
+from app import app
+import json
+from flask import render_template, request, redirect, url_for, session, make_response
+from .linked_list import LinkedList  # Import the LinkedList class
+
+
+# Create a LinkedList instance
+linkedlist_stack = LinkedList()
+app.secret_key = 'temporary-key'
+
+@app.route('/queue', methods=['GET', 'POST'])
+def queue_home():
+    queue_type = session.get('queue_type', 'queue')  # Default to normal queue
+    data = request.form.get('data', '').strip()  # Get data input from the form
+    validation_message = session.get('validation_message', None)
+
+    if request.method == 'POST':
+        action = request.form.get('action')
+
+        if action == 'toggle_queue':  # Toggle between normal queue and double-ended queue
+            linkedlist_stack.clear()  # Reset the linked list
+            if queue_type == 'queue':
+                queue_type = 'double-ended-queue'
+                validation_message = "Switched to Double Ended Queue."
+            else:
+                queue_type = 'queue'
+                validation_message = "Switched to Queue."
+
+            session['queue_type'] = queue_type  # Update session variable
+            session['validation_message'] = validation_message
+            session.modified = True  # Force session persistence
+
+        if queue_type == 'queue':  # Basic Queue Logic
+            if action == 'add_at_end':  # Add at the end
+                if not data:
+                    validation_message = "Please input data in the input field."
+                else:
+                    linkedlist_stack.insert_at_end(data)
+                    validation_message = f"'{data}' added to the queue."
+
+            elif action == 'pop_at_start':  # Pop from the front
+                removed_data = linkedlist_stack.remove_beginning()
+                if removed_data:
+                    validation_message = f"'{removed_data}' removed from the queue."
+                else:
+                    validation_message = "The queue is empty."
+
+            elif action == 'delete_at_node':  # Delete a specific node
+                if not data:
+                    validation_message = "Please input node data to delete."
+                else:
+                    removed_data = linkedlist_stack.remove_at(data)
+                    if removed_data:
+                        validation_message = f"'{removed_data}' deleted from the queue."
+                    else:
+                        validation_message = "Node not found."
+
+        elif queue_type == 'double-ended-queue':  # Double-Ended Queue Logic
+            if action == 'add_at_end':  # Add at the end
+                if not data:
+                    validation_message = "Please input data in the input field."
+                else:
+                    linkedlist_stack.insert_at_end(data)
+                    validation_message = f"'{data}' added to the double-ended queue."
+
+            elif action == 'add_at_start':  # Add at the start
+                if not data:
+                    validation_message = "Please input data in the input field."
+                else:
+                    linkedlist_stack.insert_at_beginning(data)
+                    validation_message = f"'{data}' added to the start of the double-ended queue."
+
+            elif action == 'pop_at_start':  # Pop from the front
+                removed_data = linkedlist_stack.remove_beginning()
+                if removed_data:
+                    validation_message = f"'{removed_data}' removed from the double-ended queue."
+                else:
+                    validation_message = "The double-ended queue is empty."
+
+            elif action == 'pop_at_end':  # Pop from the end
+                removed_data = linkedlist_stack.remove_at_end()
+                if removed_data:
+                    validation_message = f"'{removed_data}' removed from the end of the double-ended queue."
+                else:
+                    validation_message = "The double-ended queue is empty."
+
+            elif action == 'delete_at_node':  # Delete a specific node
+                if not data:
+                    validation_message = "Please input node data to delete."
+                else:
+                    removed_data = linkedlist_stack.remove_at(data)
+                    if removed_data:
+                        validation_message = f"'{removed_data}' deleted from the double-ended queue."
+                    else:
+                        validation_message = "Node not found."
+
+
+        session['validation_message'] = validation_message
+        linked_list_data = linkedlist_stack.to_list()  # Get linked list as a string
+        resp = make_response(redirect(url_for('queue_home')))
+        resp.set_cookie('linked_list_data', json.dumps(linked_list_data))
+        return resp
+
+    return render_template(
+    'queue.html',
+    queue_type=queue_type,
+    validation_message=validation_message,
+    linked_list_items=linkedlist_stack.to_list(),
+    title='Queue Operations'
+)

--- a/portfolio/app/templates/queue.html
+++ b/portfolio/app/templates/queue.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{{ title }}</title>
+</head>
+<body>
+    <h1>{{ title }}</h1>
+    <form method="POST">
+        <input type="text" name="data" placeholder="{% if validation_message and validation_message != 'Please input node data to delete.' %}Enter data{% else %}Enter node data to delete{% endif %}">
+        <div>
+            <button type="submit" name="action" value="add_at_end">Add at End</button>
+            <button type="submit" name="action" value="pop_at_start">Pop at Start</button>
+            <button type="submit" name="action" value="delete_at_node">Delete at Node</button>
+            {% if queue_type == 'double-ended-queue' %}
+                <button type="submit" name="action" value="add_at_start">Add at Start</button>
+                <button type="submit" name="action" value="pop_at_end">Pop at End</button>
+            {% endif %}
+        </div>
+        <button type="submit" name="action" value="toggle_queue">
+            {% if queue_type == 'queue' %}
+                Switch to Double Ended Queue
+            {% else %}
+                Switch to Queue
+            {% endif %}
+        </button>
+    </form>
+    
+    <div>
+        <h2>Current {{ queue_type | capitalize }}</h2>
+        <p>{{ linked_list_items if linked_list_items else 'No items in the list.' }}</p>
+    </div>
+    
+    <div>
+        {% if validation_message %}
+            <p>{{ validation_message }}</p>
+        {% endif %}
+    </div>
+</body>
+</html>


### PR DESCRIPTION
### Overview
This pull request introduces the backend implementation for queue and double-ended queue functionalities. The system supports basic operations for both types and allows toggling between them.

### Features
- **Queue Operations:**
  - Add at the end.
  - Pop from the front.
  - Delete specific nodes.
  
- **Double-Ended Queue Operations:**
  - Add at the start.
  - Add at the end.
  - Pop from the front.
  - Pop from the end.
  - Delete specific nodes.

- **Queue Toggle:**
  - Added a toggle to switch between queue and double-ended queue.
  - Linked list structure resets when toggling.

### Changes
- Updated backend route to handle queue operations dynamically based on `queue_type`.
- Integrated session management for queue type and validation messages.
- Enhanced form and button logic in the frontend to align with the backend.

### Testing
- Tested all operations for both queue types.
- Verified toggle functionality works without affecting individual queue operations.