### PR TITLE
Add step-by-step infix to postfix conversion with detailed steps display

### DIFF
--- a/portfolio/app/templates/infix_to_postfix.html
+++ b/portfolio/app/templates/infix_to_postfix.html
@@ -88,16 +88,46 @@
                         </div>
                     </div>
             
-                    <!-- Right Side (Info Box) -->
-                    <div class="right-side">
-                        <div class="info-box">
-                            <div class="info-header">
-                                <h3>Steps:</h3>
+                    <div class="info-box">
+                        <div class="info-header">
+                            <h3>Steps:</h3>
+                        </div>
+                        <div class="horizontal-line"></div>
+                        <div class="steps-content">
+                            <div class="step">
+                                <div class="step-column">
+                                    <p><strong>Expression:</strong></p>
+                                    {% for step in steps %}
+                                        <p>{{ step.expression }}</p>
+                                    {% endfor %}
+                                </div>
+                                <div class="step-column">
+                                    <p><strong>Stack:</strong></p>
+                                    {% for step in steps %}
+                                        <p>{{ step.stack }}</p>
+                                    {% endfor %}
+                                </div>
+                                <div class="step-column">
+                                    <p><strong>Postfix:</strong></p>
+                                    {% for step in steps %}
+                                        <p>{{ step.postfix }}</p>
+                                    {% endfor %}
+                                </div>
                             </div>
-                            <div class="horizontal-line"></div>
-                            <!-- Add steps content here -->
                         </div>
                     </div>
+                    <!-- ...existing code... -->
+                    
+                    <style>
+                        .step {
+                            display: flex;
+                            justify-content: space-between;
+                        }
+                        .step-column {
+                            flex: 1;
+                            margin-right: 10px;
+                        }
+                    </style>
                 </div>
             </form>
         </div>


### PR DESCRIPTION
- Modified the infix_to_postfix function to include step-by-step details.
- Updated the Flask route to pass these steps to the template.
- Updated the HTML template to display the expressions, stack, and postfix in a column layout within the info-box.
- Ensured that each step shows only the current character in the expression.
- Improved the user interface to present the conversion process clearly.