### PR TITLE
Fix Validation String Conflict in Queue and Linked List Notifications

### DIFF
--- a/portfolio/app/routes/queue.py
+++ b/portfolio/app/routes/queue.py
@@ -12,8 +12,8 @@ app.secret_key = 'temporary-key'
 def queue_home():
     queue_type = session.get('queue_type', 'queue')  # Default to normal queue
     data = request.form.get('data', '').strip()  # Get data input from the form
-    validation_message = session.get('validation_message', None)
-
+    validation_string = session.get('validation_string', None)
+    
     if request.method == 'POST':
         action = request.form.get('action')
 
@@ -21,81 +21,81 @@ def queue_home():
             linkedlist_stack.clear()  # Reset the linked list
             if queue_type == 'queue':
                 queue_type = 'double-ended-queue'
-                validation_message = "Switched to Double Ended Queue."
+                validation_string = "Switched to Double Ended Queue."
             else:
                 queue_type = 'queue'
-                validation_message = "Switched to Queue."
+                validation_string = "Switched to Queue."
 
             session['queue_type'] = queue_type  # Update session variable
-            session['validation_message'] = validation_message
+            session['validation_string'] = validation_string
             session.modified = True  # Force session persistence
 
         if queue_type == 'queue':  # Basic Queue Logic
             if action == 'add_at_end':  # Add at the end
                 if not data:
-                    validation_message = "Please input data in the input field."
+                    validation_string = "Please input data in the input field."
                 else:
                     linkedlist_stack.insert_at_end(data)
-                    validation_message = f"'{data}' added to the queue."
+                    validation_string = f"'{data}' added to the queue."
 
             elif action == 'pop_at_start':  # Pop from the front
                 removed_data = linkedlist_stack.remove_beginning()
                 if removed_data:
-                    validation_message = f"'{removed_data}' removed from the queue."
+                    validation_string = f"'{removed_data}' removed from the queue."
                 else:
-                    validation_message = "The queue is empty."
+                    validation_string = "The queue is empty."
 
             elif action == 'delete_at_node':  # Delete a specific node
                 if not data:
-                    validation_message = "Please input node data to delete."
+                    validation_string = "Please input node data to delete."
                 else:
                     removed_data = linkedlist_stack.remove_at(data)
                     if removed_data:
-                        validation_message = f"'{removed_data}' deleted from the queue."
+                        validation_string = f"'{removed_data}' deleted from the queue."
                     else:
-                        validation_message = "Node not found."
+                        validation_string = "Node not found."
 
         elif queue_type == 'double-ended-queue':  # Double-Ended Queue Logic
             if action == 'add_at_end':  # Add at the end
                 if not data:
-                    validation_message = "Please input data in the input field."
+                    validation_string = "Please input data in the input field."
                 else:
                     linkedlist_stack.insert_at_end(data)
-                    validation_message = f"'{data}' added to the double-ended queue."
+                    validation_string = f"'{data}' added to the double-ended queue."
 
             elif action == 'add_at_start':  # Add at the start
                 if not data:
-                    validation_message = "Please input data in the input field."
+                    validation_string = "Please input data in the input field."
                 else:
                     linkedlist_stack.insert_at_beginning(data)
-                    validation_message = f"'{data}' added to the start of the double-ended queue."
+                    validation_string = f"'{data}' added to the start of the double-ended queue."
 
             elif action == 'pop_at_start':  # Pop from the front
                 removed_data = linkedlist_stack.remove_beginning()
                 if removed_data:
-                    validation_message = f"'{removed_data}' removed from the double-ended queue."
+                    validation_string = f"'{removed_data}' removed from the double-ended queue."
                 else:
-                    validation_message = "The double-ended queue is empty."
+                    validation_string = "The double-ended queue is empty."
 
             elif action == 'pop_at_end':  # Pop from the end
                 removed_data = linkedlist_stack.remove_at_end()
                 if removed_data:
-                    validation_message = f"'{removed_data}' removed from the end of the double-ended queue."
+                    validation_string = f"'{removed_data}' removed from the end of the double-ended queue."
                 else:
-                    validation_message = "The double-ended queue is empty."
+                    validation_string = "The double-ended queue is empty."
 
             elif action == 'delete_at_node':  # Delete a specific node
                 if not data:
-                    validation_message = "Please input node data to delete."
+                    validation_string = "Please input node data to delete."
                 else:
                     removed_data = linkedlist_stack.remove_at(data)
                     if removed_data:
-                        validation_message = f"'{removed_data}' deleted from the double-ended queue."
+                        validation_string = f"'{removed_data}' deleted from the double-ended queue."
                     else:
-                        validation_message = "Node not found."
+                        validation_string = "Node not found."
 
 
-        session['validation_message'] = validation_message
+        session['validation_string'] = validation_string
         linked_list_data = linkedlist_stack.to_list()  # Get linked list as a string
         resp = make_response(redirect(url_for('queue_home')))
         resp.set_cookie('linked_list_data', json.dumps(linked_list_data))
@@ -104,7 +104,7 @@ def queue_home():
     return render_template(
     'queue.html',
     queue_type=queue_type,
-    validation_message=validation_message,
+    validation_string=validation_string,
     linked_list_items=linkedlist_stack.to_list(),
     title='Queue Operations'
 )

--- a/portfolio/app/templates/queue.html
+++ b/portfolio/app/templates/queue.html
@@ -8,7 +8,7 @@
 <body>
     <h1>{{ title }}</h1>
     <form method="POST">
-        <input type="text" name="data" placeholder="{% if validation_message and validation_message != 'Please input node data to delete.' %}Enter data{% else %}Enter node data to delete{% endif %}">
+        <input type="text" name="data" placeholder="{% if validation_string and validation_string != 'Please input node data to delete.' %}Enter data{% else %}Enter node data to delete{% endif %}">
         <div>
             <button type="submit" name="action" value="add_at_end">Add at End</button>
             <button type="submit" name="action" value="pop_at_start">Pop at Start</button>
@@ -33,8 +33,8 @@
     </div>
     
     <div>
-        {% if validation_message %}
-            <p>{{ validation_message }}</p>
+        {% if validation_string %}
+            <p>{{ validation_string }}</p>
         {% endif %}
     </div>
 </body>


### PR DESCRIPTION
This pull request resolves a naming conflict between the queue and linked-list routes in the Flask application. The variable validation_message used for notifications in the linked-list route has been renamed to validation_string in the queue route. This ensures that session variables and notifications remain isolated between the two routes, avoiding potential clashes or unexpected behavior.

Key changes:
- Renamed validation_message to validation_string in the queue route logic.
- Updated all references to validation_message in the queue route and template context.

This fix preserves functionality and improves code clarity by maintaining distinct variable names for each route's context.