### PR TITLE
Add Timer to Hide Notification in Queue Page After 5 Seconds

### DIFF
--- a/portfolio/app/static/scripts/queue-script.js
+++ b/portfolio/app/static/scripts/queue-script.js
@@ -25,3 +25,18 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 });
+
+document.addEventListener("DOMContentLoaded", () => {
+    const validationBox = document.getElementById("validation-box");
+
+    if (validationBox) {
+        // Check if the validation box contains content
+        const validationText = validationBox.querySelector("p");
+        if (validationText && validationText.textContent.trim() !== "") {
+            // Set a timer to hide the validation box after 5 seconds
+            setTimeout(() => {
+                validationBox.style.display = "none";
+            }, 5000); // 5000 milliseconds = 5 seconds
+        }
+    }
+});


### PR DESCRIPTION
This pull request implements a feature to automatically hide the notification/validation string displayed in the validation box in the Queue page after 5 seconds. 

The key changes include:
- Added a JavaScript function to detect the presence of the validation string and hide the `validation-box` element after a delay.
- Ensured compatibility with existing functionality by verifying the content before applying the timer.

This improvement enhances the user experience by removing outdated notifications automatically, reducing the need for manual interaction.