### PR TITLE
Feature: Add How to Use modals in each lab works.

### DIFF
--- a/portfolio/app/routes/infix_to_postfix.py
+++ b/portfolio/app/routes/infix_to_postfix.py
@@ -242,7 +242,7 @@ def Infix_to_Postfix():
     response.set_cookie('steps_data', '', expires=0)
     return response
 
-# Dictionary to store the How To Use data
+# List to store the How To Use data
 def get_instruction_steps():
     return [
         "Enter your mathematical expression in the input field using standard infix notation (e.g., \"3 + 4 * 2\").",

--- a/portfolio/app/routes/infix_to_postfix.py
+++ b/portfolio/app/routes/infix_to_postfix.py
@@ -227,15 +227,30 @@ def Infix_to_Postfix():
     output = request.cookies.get('output', '')
     compressed_steps = request.cookies.get('steps_data', '')
     steps = decompress_data(compressed_steps)
+    instruction_steps = get_instruction_steps()
     
     response = make_response(render_template('infix_to_postfix.html', 
                                            title="Infix To Postfix",
                                            input=input_expr,
                                            output=output,
-                                           steps=steps))
+                                           steps=steps,
+                                           instruction_steps=instruction_steps))
     
     # Clear cookies after rendering
     response.set_cookie('input_expr', '', expires=0)
     response.set_cookie('output', '', expires=0)
     response.set_cookie('steps_data', '', expires=0)
     return response
+
+# Dictionary to store the How To Use data
+def get_instruction_steps():
+    return [
+        "Enter your mathematical expression in the input field using standard infix notation (e.g., \"3 + 4 * 2\").",
+        "Click the \"Convert\" button to convert your infix expression to postfix notation.",
+        "View your converted postfix expression in the output box.",
+        "Use the toggle button with the eye symbol to show/hide the step-by-step conversion process on the right side.",
+        "View the detailed conversion steps in the table, showing each operation and stack changes.",
+        "Clear the input and output at any time using the \"Reset\" button.",
+        "For valid expressions, use: Numbers (0-9), Operators (+, -, *, /, ^) and Parentheses ( ). Spaces between numbers and operators are optional.",
+        "Watch for error messages if your input expression is invalid."
+    ]

--- a/portfolio/app/routes/linked_list.py
+++ b/portfolio/app/routes/linked_list.py
@@ -133,6 +133,7 @@ def linkedlist_home():
     validation_type = session.get('validation_type', None)
     data = request.form.get('data', '').strip()
     highlighted_item = None  # New variable to track the item to highlight
+    instruction_steps = get_instruction_steps()  # Get the instruction steps for the How To Use section
 
     # Retrieve linked list data from cookies
     linked_list_data = request.cookies.get('linked_list_data')
@@ -239,6 +240,18 @@ def linkedlist_home():
         validation_message=validation_message,
         validation_type=validation_type,
         empty_list=linkedlist.head is None,
-        highlighted_item=highlighted_item, # Pass highlighted item to the template
-        title = 'Linked List'
+        highlighted_item=highlighted_item,
+        instruction_steps=instruction_steps,  # Add instruction steps for the How To Use section
+        title='Linked List'
     )
+# Dictionary to store the How To Use data
+def get_instruction_steps():
+    return [
+        "Enter your desired data in the input field.",
+        "Click the \"Add\" button and select either \"Add at Beginning\" to insert the value at the start or \"Add at End\" to append it to the list.",
+        "To remove elements, click the \"Delete\" button and choose \"Delete at Beginning\" to remove the first node or \"Delete at End\" to remove the last node.",
+        " For deleting a specific value, type the value you want to remove in the input field, then click \"Delete\" and select \"Delete a Node\".",
+        "Use the \"Search\" button to find a specific value in the list, which will highlight the matching node if found",
+        "Watch for success/error messages at the top of the box that will confirm your actions.",
+        "Follow the linked list connections through the arrow (→) indicators, with an \"X\" marking the end of the list.",
+    ]

--- a/portfolio/app/routes/linked_list.py
+++ b/portfolio/app/routes/linked_list.py
@@ -244,7 +244,8 @@ def linkedlist_home():
         instruction_steps=instruction_steps,  # Add instruction steps for the How To Use section
         title='Linked List'
     )
-# Dictionary to store the How To Use data
+
+# List to store the How To Use data
 def get_instruction_steps():
     return [
         "Enter your desired data in the input field.",

--- a/portfolio/app/routes/queue.py
+++ b/portfolio/app/routes/queue.py
@@ -15,6 +15,7 @@ def queue_home():
     queue_type = session.get('queue_type', 'queue')  # Default to normal queue
     data = request.form.get('data', '').strip()  # Get data input from the form
     validation_string = session.get('validation_string', None)
+    instruction_steps = get_instruction_steps() 
     
     if request.method == 'POST':
         action = request.form.get('action')
@@ -120,5 +121,30 @@ def queue_home():
         queue_type=queue_type,
         validation_string=validation_string,  # Only show validation if set
         linked_list_items=linkedlist_stack.to_list(),
+        instruction_steps=instruction_steps,
         title='Queue Operations'
     )
+
+# List to store the How To Use data
+def get_instruction_steps():
+    return [
+        "Begin by entering your desired value in the input field.",
+
+        "Select the operation you would like to perform on the queue using the dropdown menu. You can switch between \n"
+        "a Simple Queue and a Double-Ended Queue by clicking the specific toggle queue button.",
+
+        "For Simple Queue, use the \"Add at Rear\" button to insert values at the back, maintaining the First-In-First-Out (FIFO) principle; \n"
+        "for Double-Ended Queue, click the \"Add Operations\" dropdown to choose between adding at front or rear.",
+
+        "Remove elements using \"Pop at Front\" in Simple Queue to delete the first element; in Double-Ended Queue, \n"
+        "use the \"Delete Operations\" dropdown to remove from either end.",
+
+        "Watch the visual feedback as purple highlights indicate active operations, and arrows show the flow direction.",
+
+        "Monitor the success/error messages at the top of the screen that confirm your actions and provide helpful feedback about queue status.",
+
+        "Observe how elements are displayed as rounded rectangles with connecting arrows, showing the relationship between items in both queue types.",
+
+        "Note that when the queue is empty, a message \"Queue is empty\" appears, and operations are performed based on the selected queue type \n"
+        "Simple Queue maintains strict FIFO, while Double-Ended Queue allows flexible operations at both ends."
+    ]

--- a/portfolio/app/static/scripts/infix-to-postfix-script.js
+++ b/portfolio/app/static/scripts/infix-to-postfix-script.js
@@ -6,7 +6,6 @@ function clearAll() {
 
 // Function to toggle between eye and eye-slash icons
 // Uses Font Awesome classes for smooth transition
-/* filepath: /c:/Users/flore/Jace's Coding Projects/dsa_portfolio/portfolio/app/static/scripts/infix-to-postfix.js */
 function toggleView() {
     const splitContainer = document.querySelector('.split-container');
     const icon = document.querySelector('.toggle-button i');
@@ -21,3 +20,26 @@ function toggleView() {
         icon.classList.add('fa-eye');
     }
 }
+
+// Detect page refresh and reset the cookie
+window.addEventListener("beforeunload", function() {
+    document.cookie = "linked_list_data=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
+});
+
+// For modal contents
+document.querySelector('.infix-to-postfix-text h1').addEventListener('click', () => {
+    document.getElementById('howToUseModal').classList.add('active');
+    document.querySelector('.modal-content').classList.add('active');
+});
+
+document.getElementById('closeModal').addEventListener('click', () => {
+    document.getElementById('howToUseModal').classList.remove('active');
+    document.querySelector('.modal-content').classList.remove('active');
+});
+
+document.querySelector('.modal-overlay').addEventListener('click', (e) => {
+    if (e.target.classList.contains('modal-overlay')) {
+        document.getElementById('howToUseModal').classList.remove('active');
+        document.querySelector('.modal-content').classList.remove('active');
+    }
+});

--- a/portfolio/app/static/scripts/linked-list-script.js
+++ b/portfolio/app/static/scripts/linked-list-script.js
@@ -73,7 +73,6 @@ document.addEventListener('DOMContentLoaded', () => {
 
 // Detect page refresh and reset the cookie
 window.addEventListener("beforeunload", function() {
-    // Clear the cookie when page refreshes
     document.cookie = "linked_list_data=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
 });
 
@@ -83,7 +82,7 @@ document.querySelector('.linked-list-text h1').addEventListener('click', () => {
     document.querySelector('.modal-content').classList.add('active');
 });
 
-document.querySelector('.close-modal').addEventListener('click', () => {
+document.getElementById('closeModal').addEventListener('click', () => {
     document.getElementById('howToUseModal').classList.remove('active');
     document.querySelector('.modal-content').classList.remove('active');
 });

--- a/portfolio/app/static/scripts/linked-list-script.js
+++ b/portfolio/app/static/scripts/linked-list-script.js
@@ -76,3 +76,21 @@ window.addEventListener("beforeunload", function() {
     // Clear the cookie when page refreshes
     document.cookie = "linked_list_data=; expires=Thu, 01 Jan 1970 00:00:00 GMT";
 });
+
+// For modal contents
+document.querySelector('.linked-list-text h1').addEventListener('click', () => {
+    document.getElementById('howToUseModal').classList.add('active');
+    document.querySelector('.modal-content').classList.add('active');
+});
+
+document.querySelector('.close-modal').addEventListener('click', () => {
+    document.getElementById('howToUseModal').classList.remove('active');
+    document.querySelector('.modal-content').classList.remove('active');
+});
+
+document.querySelector('.modal-overlay').addEventListener('click', (e) => {
+    if (e.target.classList.contains('modal-overlay')) {
+        document.getElementById('howToUseModal').classList.remove('active');
+        document.querySelector('.modal-content').classList.remove('active');
+    }
+});

--- a/portfolio/app/static/scripts/queue-script.js
+++ b/portfolio/app/static/scripts/queue-script.js
@@ -40,3 +40,21 @@ document.addEventListener("DOMContentLoaded", () => {
         }
     }
 });
+
+// For modal contents
+document.querySelector('.queue-conversion-text h1', '.empty p').addEventListener('click', () => {
+    document.getElementById('howToUseModal').classList.add('active');
+    document.querySelector('.modal-content').classList.add('active');
+});
+
+document.getElementById('closeModal').addEventListener('click', () => {
+    document.getElementById('howToUseModal').classList.remove('active');
+    document.querySelector('.modal-content').classList.remove('active');
+});
+
+document.querySelector('.modal-overlay').addEventListener('click', (e) => {
+    if (e.target.classList.contains('modal-overlay')) {
+        document.getElementById('howToUseModal').classList.remove('active');
+        document.querySelector('.modal-content').classList.remove('active');
+    }
+});

--- a/portfolio/app/static/styles/infix-to-postfix-style.css
+++ b/portfolio/app/static/styles/infix-to-postfix-style.css
@@ -46,6 +46,133 @@ body{
     width: 100%;
 }
 
+/*Infix to Postfix Text Hover */
+.infix-to-postfix-text h1 {
+    color: #000000;
+    transition: color 0.3s ease;
+    position: relative;
+}
+
+.infix-to-postfix-text h1:hover {
+    color: #6b00a1;
+    cursor: pointer;
+}
+
+.infix-to-postfix-text h1::after {
+    position: absolute;
+    right: -20px;
+    top: 50%;
+    font-size: 40px;
+    opacity: 0;
+    color: #6b00a1;
+    transition: opacity 0.3s ease-in-out;
+}
+
+/* Modal Styling */
+.modal-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+    z-index: 1000;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.modal-content {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    padding: 30px;
+    border-radius: 10px;
+    width: 80%;
+    max-width: 700px;
+    z-index: 1001;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    border: 2px solid #000000;
+    border-radius: 20px;
+    background: #E2B2E5;
+    backdrop-filter: blur(40px);
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+}
+
+.modal-overlay.active {
+    display: block;
+    opacity: 1;
+    transition: opacity 0.3s ease;
+}
+
+.modal-content.active {
+    display: block;
+    animation: fadeIn 0.3s ease forwards;
+}
+
+.modal-content.inactive {
+    animation: fadeOut 0.3s ease forwards;
+}
+
+#closeModal {
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    cursor: pointer;
+    font-size: 20px;
+    color: #000000;
+}
+
+.modal-content h2 {
+    margin: 0 0 15px;
+    font-size: 35px;
+    color: #000000;
+    font-weight: bolder;
+    text-align: center;
+    letter-spacing: px;
+}
+
+.modal-content-text {
+    font-size: 20px;
+    color: #000000;
+    font-weight: lighter;
+}
+
+.modal-content-text ol {
+    text-align: left;
+    width: fit-content;
+    margin: 0 auto;
+    padding-left: 20px;
+}
+
+.modal-content-text li {
+    padding: 5px 0;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translate(-50%, -60%);
+    }
+    to {
+        opacity: 1;
+        transform: translate(-50%, -50%);
+    }
+}
+
+@keyframes fadeOut {
+    from {
+        opacity: 1;
+        transform: translate(-50%, -50%);
+    }
+    to {
+        opacity: 0;
+        transform: translate(-50%, -60%);
+    }
+}
+
 /* Media query for smaller screens */
 @media screen and (max-width: 768px) {
     .infix-to-postfix-text h1 {

--- a/portfolio/app/static/styles/linked-list-style.css
+++ b/portfolio/app/static/styles/linked-list-style.css
@@ -98,9 +98,19 @@ main{
     box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 }
 
-.modal-overlay.active, .modal-content.active {
+.modal-overlay.active {
     display: block;
     opacity: 1;
+    transition: opacity 0.3s ease;
+}
+
+.modal-content.active {
+    display: block;
+    animation: fadeIn 0.3s ease forwards;
+}
+
+.modal-content.inactive {
+    animation: fadeOut 0.3s ease forwards;
 }
 
 #closeModal {
@@ -135,6 +145,28 @@ main{
 
 .modal-content-text li {
     padding: 5px 0;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translate(-50%, -60%);
+    }
+    to {
+        opacity: 1;
+        transform: translate(-50%, -50%);
+    }
+}
+
+@keyframes fadeOut {
+    from {
+        opacity: 1;
+        transform: translate(-50%, -50%);
+    }
+    to {
+        opacity: 0;
+        transform: translate(-50%, -60%);
+    }
 }
 
 /* For Output box */

--- a/portfolio/app/static/styles/linked-list-style.css
+++ b/portfolio/app/static/styles/linked-list-style.css
@@ -46,7 +46,6 @@ main{
 
 .linked-list-text h1:hover {
     color: #6b00a1;
-    animation: textWave 1s ease infinite;
     cursor: pointer;
 }
 

--- a/portfolio/app/static/styles/linked-list-style.css
+++ b/portfolio/app/static/styles/linked-list-style.css
@@ -126,8 +126,9 @@ main{
     margin: 0 0 15px;
     font-size: 35px;
     color: #000000;
-    font-weight: lighter;
+    font-weight: bolder;
     text-align: center;
+    letter-spacing: 1px;
 }
 
 .modal-content-text {

--- a/portfolio/app/static/styles/linked-list-style.css
+++ b/portfolio/app/static/styles/linked-list-style.css
@@ -37,6 +37,108 @@ main{
     font-weight: 400;
 }
 
+/* Linked List Text */
+.linked-list-text h1 {
+    color: #000000;
+    transition: color 0.3s ease;
+    position: relative;
+}
+
+.linked-list-text h1:hover {
+    color: #6b00a1;
+    animation: textWave 1s ease infinite;
+    cursor: pointer;
+}
+
+.linked-list-text h1::after {
+    content: "?";
+    position: absolute;
+    right: -20px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 0.8em;
+    opacity: 0;
+    color: #6b00a1;
+    transition: opacity 0.3s ease-in-out;
+}
+
+.linked-list-text h1:hover::after {
+    opacity: 1;
+}
+
+/* Modal Styling */
+.modal-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+    z-index: 1000;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.modal-content {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    padding: 30px;
+    border-radius: 10px;
+    width: 80%;
+    max-width: 600px;
+    z-index: 1001;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    border: 2px solid #000000;
+    border-radius: 20px;
+    background: #E2B2E5;
+    backdrop-filter: blur(40px);
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+}
+
+.modal-overlay.active, .modal-content.active {
+    display: block;
+    opacity: 1;
+}
+
+.close-modal {
+    position: absolute;
+    top: -1px;
+    right: 18px;
+    cursor: pointer;
+    font-size: 50px;
+    color: #000000;
+}
+
+.modal-content h2 {
+    margin: 0 0 15px;
+    font-size: 35px;
+    color: #000000;
+    font-weight: lighter;
+    text-align: center;
+}
+
+.modal-content-text {
+    font-size: 20px;
+    color: #000000;
+    font-weight: lighter;
+}
+
+.modal-content-text ol {
+    text-align: left;
+    width: fit-content;
+    margin: 0 auto;
+    padding-left: 20px;
+}
+
+.modal-content-text li {
+    padding: 5px 0;
+}
+
+/* For Output box */
 .output-box {
     width: 80%;
     height: 450px;

--- a/portfolio/app/static/styles/linked-list-style.css
+++ b/portfolio/app/static/styles/linked-list-style.css
@@ -56,7 +56,7 @@ main{
     right: -20px;
     top: 50%;
     transform: translateY(-50%);
-    font-size: 0.8em;
+    font-size: 40px;
     opacity: 0;
     color: #6b00a1;
     transition: opacity 0.3s ease-in-out;
@@ -104,12 +104,12 @@ main{
     opacity: 1;
 }
 
-.close-modal {
+#closeModal {
     position: absolute;
-    top: -1px;
-    right: 18px;
+    top: 15px;
+    right: 15px;
     cursor: pointer;
-    font-size: 50px;
+    font-size: 20px;
     color: #000000;
 }
 

--- a/portfolio/app/static/styles/queue-style.css
+++ b/portfolio/app/static/styles/queue-style.css
@@ -37,6 +37,139 @@ body{
     margin-top: 20px;
 }
 
+/* Modal Styling */
+.queue-conversion-text h1 {
+    color: #000000;
+    transition: color 0.3s ease;
+    position: relative;
+}
+
+.queue-conversion-text h1:hover {
+    color: #6b00a1;
+    cursor: pointer;
+}
+
+.queue-conversion-text h1::after {
+    content: "?";
+    position: absolute;
+    right: -20px;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 40px;
+    opacity: 0;
+    color: #6b00a1;
+    transition: opacity 0.3s ease-in-out;
+}
+
+.queue-conversion-text h1:hover::after {
+    opacity: 1;
+}
+
+
+.modal-overlay {
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.7);
+    z-index: 1000;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+}
+
+.modal-content {
+    position: fixed;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    padding: 30px;
+    border-radius: 10px;
+    width: 80%;
+    max-width: 800px;
+    z-index: 1001;
+    opacity: 0;
+    transition: opacity 0.3s ease;
+    border: 2px solid #000000;
+    border-radius: 20px;
+    background: #E2B2E5;
+    backdrop-filter: blur(40px);
+    box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+}
+
+.modal-overlay.active {
+    display: block;
+    opacity: 1;
+    transition: opacity 0.3s ease;
+}
+
+.modal-content.active {
+    display: block;
+    animation: fadeIn 0.3s ease forwards;
+}
+
+.modal-content.inactive {
+    animation: fadeOut 0.3s ease forwards;
+}
+
+#closeModal {
+    position: absolute;
+    top: 15px;
+    right: 15px;
+    cursor: pointer;
+    font-size: 20px;
+    color: #000000;
+}
+
+.modal-content h2 {
+    margin: 0 0 15px;
+    font-size: 35px;
+    color: #000000;
+    font-weight: bolder;
+    text-align: center;
+    letter-spacing: 1px;
+}
+
+.modal-content-text {
+    font-size: 20px;
+    color: #000000;
+    font-weight: lighter;
+}
+
+.modal-content-text ol {
+    text-align: left;
+    width: fit-content;
+    margin: 0 auto;
+    padding-left: 20px;
+}
+
+.modal-content-text li {
+    padding: 5px 0;
+}
+
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+        transform: translate(-50%, -60%);
+    }
+    to {
+        opacity: 1;
+        transform: translate(-50%, -50%);
+    }
+}
+
+@keyframes fadeOut {
+    from {
+        opacity: 1;
+        transform: translate(-50%, -50%);
+    }
+    to {
+        opacity: 0;
+        transform: translate(-50%, -60%);
+    }
+}
+
 /*** Queue Conversion ***/
 /* Validation Box */
 .validation {

--- a/portfolio/app/templates/infix_to_postfix.html
+++ b/portfolio/app/templates/infix_to_postfix.html
@@ -50,6 +50,21 @@
                     <h1>Infix to Postfix Converter</h1>
                 </div>
             </div>
+
+            <!-- "How to Use" Modal -->
+            <div class="modal-overlay" id="howToUseModal">
+                <div class="modal-content">
+                    <i class="fa-solid fa-x" id="closeModal"></i>
+                    <h2>How to Use Infix to Postfix Converter?</h2>
+                    <div class="modal-content-text">
+                        <ol>
+                            {% for step in instruction_steps %}
+                                <li>{{ step }}</li>
+                            {% endfor %}
+                        </ol>
+                    </div>
+                </div>
+            </div>
     
             <!-- Form for input and output -->
             <form action="/infix-to-postfix" method="POST">

--- a/portfolio/app/templates/linked-list.html
+++ b/portfolio/app/templates/linked-list.html
@@ -66,6 +66,28 @@
                     </div>
                 </div>
             </div>
+
+            <!-- How to Use Modal -->
+            <div class="modal-overlay" id="howToUseModal">
+                <div class="modal-content">
+                    <span class="close-modal">&times;</span>
+                    <h2> How to Use Linked List Simulator</h2>
+                        <div class="modal-content-text">
+                        <ol>
+                            <li>Enter your desired data in the input field.</li>
+                            <li>Click the "Add" button and select either "Add at Beginning" to insert the value at the start or 
+                                "Add at End" to append it to the list.</li>
+                            <li>To remove elements, click the "Delete" button and choose "Delete at Beginning" to remove the 
+                                first node or "Delete at End" to remove the last node.</li>
+                            <li>For deleting a specific value, type the value you want to remove in the input field, 
+                                then click "Delete" and select "Delete a Node".</li>
+                            <li>Use the "Search" button to find a specific value in the list, which will highlight the matching node if found.</li>
+                            <li> Watch for success/error messages at the top of the box that will confirm your actions. </li>
+                            <li>  Follow the linked list connections through the arrow (→) indicators, with an X marking the end of the list.</li>
+                        </ol>
+                        </div>
+                </div>
+            </div>
             
            <!-- Output Box -->
             <div class="output-box">

--- a/portfolio/app/templates/linked-list.html
+++ b/portfolio/app/templates/linked-list.html
@@ -67,25 +67,18 @@
                 </div>
             </div>
 
-            <!-- How to Use Modal -->
+            <!-- "How to Use" Modal -->
             <div class="modal-overlay" id="howToUseModal">
                 <div class="modal-content">
-                    <span class="close-modal">&times;</span>
-                    <h2> How to Use Linked List Simulator</h2>
-                        <div class="modal-content-text">
+                    <i class="fa-solid fa-x" id="closeModal"></i>
+                    <h2>How to Use Linked List Simulator?</h2>
+                    <div class="modal-content-text">
                         <ol>
-                            <li>Enter your desired data in the input field.</li>
-                            <li>Click the "Add" button and select either "Add at Beginning" to insert the value at the start or 
-                                "Add at End" to append it to the list.</li>
-                            <li>To remove elements, click the "Delete" button and choose "Delete at Beginning" to remove the 
-                                first node or "Delete at End" to remove the last node.</li>
-                            <li>For deleting a specific value, type the value you want to remove in the input field, 
-                                then click "Delete" and select "Delete a Node".</li>
-                            <li>Use the "Search" button to find a specific value in the list, which will highlight the matching node if found.</li>
-                            <li> Watch for success/error messages at the top of the box that will confirm your actions. </li>
-                            <li>  Follow the linked list connections through the arrow (→) indicators, with an X marking the end of the list.</li>
+                            {% for step in instruction_steps %}
+                                <li>{{ step }}</li>
+                            {% endfor %}
                         </ol>
-                        </div>
+                    </div>
                 </div>
             </div>
             

--- a/portfolio/app/templates/queue.html
+++ b/portfolio/app/templates/queue.html
@@ -61,7 +61,22 @@
                     </div>
                 </div>
             </div>
-                
+        
+            <!-- "How to Use" Modal -->
+            <div class="modal-overlay" id="howToUseModal">
+                <div class="modal-content">
+                    <i class="fa-solid fa-x" id="closeModal"></i>
+                    <h2>How to Use Queue Operations Simulator?</h2>
+                    <div class="modal-content-text">
+                        <ol>
+                            {% for step in instruction_steps %}
+                                <li>{{ step }}</li>
+                            {% endfor %}
+                        </ol>
+                    </div>
+                </div>
+            </div>
+
             <!-- Output Box -->
             <div class="output-box">
                 {% if linked_list_items %}
@@ -111,8 +126,8 @@
                                     <i class="fas fa-minus-circle"></i> Pop at Front
                                 </button>
                             {% else %}
+                            
                                 <!-- Double-Ended Queue Dropdowns -->
-
                                 <!-- Add Operations -->
                                 <div class="dropdown">
                                     <button type="button" class="dropdown-btn">


### PR DESCRIPTION
![Screenshot 2025-01-05 205634](https://github.com/user-attachments/assets/18bab1d7-b942-4fca-9865-0c2931a62df9)


- Added modal "How to use" in each lab projects (Linked List, Infix to Postfix, and Queue Operations)
- The title of each lab projects will serve as the button for this modal. (Might add a specific "?" button later on for each lab project pages)

Enhancements to user guidance:
Added `get_instruction_steps` function and included `instruction_steps` in the response for rendering the "How to Use" section in the following:
* [`portfolio/app/routes/infix_to_postfix.py`]
* [`portfolio/app/routes/linked_list.py`]
* [`portfolio/app/routes/queue.py`]

Modal and script updates:
Added event listeners for modal interactions and cookie reset on page refresh for the following: 
* [`portfolio/app/static/scripts/infix-to-postfix-script.js`]
* [`portfolio/app/static/scripts/linked-list-script.js`]
* [`portfolio/app/static/scripts/queue-script.js`]

Styling updates:
Added styles for modal and hover effects for the infix-to-postfix page in the following:
* [`portfolio/app/static/styles/infix-to-postfix-style.css`]
* [`portfolio/app/static/styles/linked-list-style.css`]
* [`portfolio/app/static/styles/queue-style.css`]

Template updates:
Added modal structure for displaying "How to Use" instructions for the following:
* [`portfolio/app/templates/infix_to_postfix.html`]
* [`portfolio/app/templates/linked-list.html`]
* [`portfolio/app/templates/queue.html`]