### PR TITLE
Fix: Reset inputs and session data on normal GET request

### DIFF
--- a/portfolio/app/routes/graph.py
+++ b/portfolio/app/routes/graph.py
@@ -151,19 +151,37 @@ def graph():
                 session['no_stations'] = ""
                 session['line_changes'] = []
             
+            # Set a flag to indicate that the request is a result of a POST (form submission)
+            session['form_submitted'] = True
+
             # Redirect to prevent form resubmission on refresh
-            return redirect(url_for('graph'))
-    
-    # For GET request or after redirect: display results and clear inputs
+            return redirect(url_for('graph', start=start, end=end))
+        
+    elif request.method == "GET":
+        # Check if this is a fresh GET request (not redirected after POST)
+        if not session.get('form_submitted', False):
+            # Clear session data to reset outputs
+            session.pop('from_to', None)
+            session.pop('shortest_path', None)
+            session.pop('no_stations', None)
+            session.pop('line_changes', None)
+
+            # Set start and end inputs to empty
+            start = ""
+            end = ""
+        else:
+            # Clear the flag after handling the redirected request
+            session.pop('form_submitted', None)
+
+            # Use values from the redirected GET request
+            start = request.args.get('start', '')
+            end = request.args.get('end', '')
+
     # Retrieve and clear session data
     from_to = session.pop('from_to', "")
     shortest_path = session.pop('shortest_path', "")
     no_stations = session.pop('no_stations', "")
-    line_changes_output = session.pop('line_changes', [])  # Returns list directly for template
-    
-    # Clear input fields on page load/refresh
-    start = ""
-    end = ""
+    line_changes_output = session.pop('line_changes', [])
     
     # Render template with empty inputs and any stored results
     return render_template(


### PR DESCRIPTION
### Summary:
This pull request addresses the behavior of form inputs and session data handling:
- After a normal GET request (e.g., first page load, page reload), all form inputs and session data are reset.
- After a POST request (form submission), session data is stored and the page is redirected to prevent form resubmission.
- Ensures that the form and session data behave correctly, providing a fresh state on page reloads.

### Changes:
- Added logic to reset inputs and clear session data after a normal GET request.
- Preserved session data only after form submission and redirected GET requests.
- Ensured the session is used to display results only after a valid form submission.

### Impact:
- Prevents previously submitted data from showing after a page reload.
- Clears form inputs to avoid confusion after a GET request.
- Input in start and end stations were fixed to render correctly after a redirection.