### PR TITLE
Fix: Display station lines in shortest path and update line change output in template

### DIFF
--- a/portfolio/app/static/styles/graph-style.css
+++ b/portfolio/app/static/styles/graph-style.css
@@ -22,6 +22,11 @@ body {
     margin-top: 20px;
 }
 
+.no-bullets {
+    list-style-type: none;
+    padding-left: 0;
+}
+
 .container {
     padding: 0 0 10px;
 }

--- a/portfolio/app/templates/graph.html
+++ b/portfolio/app/templates/graph.html
@@ -170,7 +170,11 @@
                     <!-- Simplified line changes output - displays list directly -->
                     <div class="line-transfers">
                         {% if line_changes_output %}
-                        <p>{{ line_changes_output }}</p>
+                            <ul class="no-bullets">
+                                {% for change in line_changes_output %}
+                                    <li>{{ change }}</li>
+                                {% endfor %}
+                            </ul>
                         {% endif %}
                     </div>
                 </div>


### PR DESCRIPTION
This pull request addresses two issues:

1. **Include lines of each station in the shortest path**:
   - The Python function responsible for displaying the shortest path has been modified to include the rail line (e.g., MRT3, LRT2) of each station in the path.
   - The updated logic ensures that the station names are displayed along with their respective lines, formatted as "Station Name (Line)".

2. **Fix line change output in template**:
   - The Jinja template for displaying line changes has been updated to render a list without bullet points.
   - A new CSS class (`no-bullets`) has been added to remove the default list styling and improve the presentation of line change details.

These changes improve the clarity and accuracy of the shortest path and line change output displayed on the web page.
